### PR TITLE
Move ecmaFeatures under parserOptions

### DIFF
--- a/packages/eslint-config-uber-jsx/eslintrc.js
+++ b/packages/eslint-config-uber-jsx/eslintrc.js
@@ -27,11 +27,9 @@ module.exports = {
   ],
   "parserOptions": {
     "ecmaFeatures": {
-      "jsx": true
+      "jsx": true,
+      "experimentalObjectRestSpread": true
     }
-  },
-  "ecmaFeatures": {
-    "experimentalObjectRestSpread": true
   },
   "plugins": [
     "react"


### PR DESCRIPTION
Otherwise it fails with eslint v4:
```
node_modules/.bin/eslint --ext .js --fix . 
eslint-config-uber-jsx:
	ESLint configuration is invalid:
	- Unexpected top-level property "ecmaFeatures".

Referenced from: <path>/.eslintrc.js
Error: eslint-config-uber-jsx:
	ESLint configuration is invalid:
	- Unexpected top-level property "ecmaFeatures".
```